### PR TITLE
Use host analytics.hel.ninja for Piwik analytics

### DIFF
--- a/kuulemma/templates/_piwik.html
+++ b/kuulemma/templates/_piwik.html
@@ -22,13 +22,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
     (function() {
-      var u=(("https:" == document.location.protocol) ? "https" : "http") + "://monitor.hel.ninja/piwik/";
+      var u=(("https:" == document.location.protocol) ? "https" : "http") + "://analytics.hel.ninja/piwik/";
       _paq.push(['setTrackerUrl', u+'piwik.php']);
       _paq.push(['setSiteId', 2]);
       var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript';
       g.defer=true; g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
     })();
   </script>
-  <noscript><p><img src="http://83.136.249.107/piwik/piwik.php?idsite=2" style="border:0;" alt="" /></p></noscript>
+  <noscript><p><img src="http://analytics.hel.ninja/piwik/piwik.php?idsite=2" style="border:0;" alt="" /></p></noscript>
   <!-- End Piwik Code -->
 {% endif %}


### PR DESCRIPTION
`monitor.hel.ninja` will be used for only monitoring purposes. The new hostname is not yet functional because of certificate issues, but it will be after this PR is merged.